### PR TITLE
Allow direct encryption of binary blobs

### DIFF
--- a/Rijndael256.Tests/RijndaelEtMTests.cs
+++ b/Rijndael256.Tests/RijndaelEtMTests.cs
@@ -142,5 +142,16 @@ namespace Rijndael256.Tests
             Assert.Equal(keyRing.CipherKey, AeKeyRingProof.CipherKey);
             Assert.True(keyRing.MacKey.SequenceEqual(AeKeyRingProof.MacKey));
         }
+
+        [Fact]
+        public void BinaryBlob()
+        {
+            var plainblob = UTF8Encoding.UTF8.GetBytes(Plaintext);
+
+            var cipherblob = RijndaelEtM.EncryptBinary(plainblob, Password, KeySize.Aes128);
+            var plainresult = RijndaelEtM.DecryptBinary(cipherblob, Password, KeySize.Aes128);
+
+            Assert.Equal(plainblob, plainresult);
+        }
     }
 }

--- a/Rijndael256.Tests/RijndaelTests.cs
+++ b/Rijndael256.Tests/RijndaelTests.cs
@@ -98,5 +98,16 @@ namespace Rijndael256.Tests
             Assert.Equal(plaintext, Plaintext);
             Assert.NotEqual(ciphertext1, ciphertext2);
         }
+
+        [Fact]
+        public void BinaryBlob()
+        {
+            var plainblob = UTF8Encoding.UTF8.GetBytes(Plaintext);
+
+            var cipherblob = Rijndael.EncryptBinary(plainblob, Password, KeySize.Aes128);
+            var plainresult = Rijndael.DecryptBinary(cipherblob, Password, KeySize.Aes128);
+
+            Assert.Equal(plainblob, plainresult);
+        }
     }
 }

--- a/Rijndael256/Rijndael.cs
+++ b/Rijndael256/Rijndael.cs
@@ -31,9 +31,7 @@ namespace Rijndael256
         /// <returns>The Base64 encoded ciphertext.</returns>
         public static string Encrypt(string plaintext, string password, KeySize keySize)
         {
-            return Convert.ToBase64String(
-                Encrypt(Encoding.UTF8.GetBytes(plaintext), password, keySize)
-                );
+            return Encrypt(Encoding.UTF8.GetBytes(plaintext), password, keySize);
         }
 
         /// <summary>
@@ -43,8 +41,8 @@ namespace Rijndael256
         /// <param name="plaintext">The plaintext to encrypt.</param>
         /// <param name="password">The password to encrypt the plaintext with.</param>
         /// <param name="keySize">The cipher key size. 256-bit is stronger, but slower.</param>
-        /// <returns>The encoded ciphertext.</returns>
-        public static byte[] Encrypt(byte[] plaintext, string password, KeySize keySize)
+        /// <returns>The Base64 encoded ciphertext.</returns>
+        public static string Encrypt(byte[] plaintext, string password, KeySize keySize)
         {
             // Generate a random IV
             var iv = Rng.GenerateRandomBytes(InitializationVectorSize);
@@ -53,7 +51,7 @@ namespace Rijndael256
             var ciphertext = Encrypt(plaintext, password, iv, keySize);
 
             // Encode the ciphertext
-            return ciphertext;
+            return Convert.ToBase64String(ciphertext);
         }
 
         /// <summary>
@@ -141,19 +139,7 @@ namespace Rijndael256
         /// <returns>The plaintext.</returns>
         public static string Decrypt(string ciphertext, string password, KeySize keySize)
         {
-            using (var ms = new MemoryStream(Convert.FromBase64String(ciphertext)))
-            {
-                // Extract the IV from the ciphertext
-                var iv = new byte[InitializationVectorSize];
-                ms.Read(iv, 0, iv.Length);
-
-                // Create a CryptoStream to decrypt the ciphertext
-                using (var cs = new CryptoStream(ms, CreateDecryptor(password, iv, keySize), CryptoStreamMode.Read))
-                {
-                    // Decrypt the ciphertext
-                    using (var sr = new StreamReader(cs, Encoding.UTF8)) return sr.ReadToEnd();
-                }
-            }
+            return Decrypt(Convert.FromBase64String(ciphertext), password, keySize);
         }
 
         /// <summary>
@@ -163,7 +149,7 @@ namespace Rijndael256
         /// <param name="password">The password to decrypt the ciphertext with.</param>
         /// <param name="keySize">The size of the cipher key used to create the ciphertext.</param>
         /// <returns>The plaintext.</returns>
-        public static byte[] Decrypt(byte[] ciphertext, string password, KeySize keySize)
+        public static string Decrypt(byte[] ciphertext, string password, KeySize keySize)
         {
             using (var ms = new MemoryStream(ciphertext))
             {
@@ -175,12 +161,7 @@ namespace Rijndael256
                 using (var cs = new CryptoStream(ms, CreateDecryptor(password, iv, keySize), CryptoStreamMode.Read))
                 {
                     // Decrypt the ciphertext
-                    using (var buffer = new MemoryStream())
-                    {
-                        cs.CopyTo(buffer);
-
-                        return buffer.ToArray();
-                    }
+                    using (var sr = new StreamReader(cs, Encoding.UTF8)) return sr.ReadToEnd();
                 }
             }
         }

--- a/Rijndael256/Rijndael.cs
+++ b/Rijndael256/Rijndael.cs
@@ -31,7 +31,9 @@ namespace Rijndael256
         /// <returns>The Base64 encoded ciphertext.</returns>
         public static string Encrypt(string plaintext, string password, KeySize keySize)
         {
-            return Encrypt(Encoding.UTF8.GetBytes(plaintext), password, keySize);
+            return Convert.ToBase64String(
+                Encrypt(Encoding.UTF8.GetBytes(plaintext), password, keySize)
+                );
         }
 
         /// <summary>
@@ -41,8 +43,8 @@ namespace Rijndael256
         /// <param name="plaintext">The plaintext to encrypt.</param>
         /// <param name="password">The password to encrypt the plaintext with.</param>
         /// <param name="keySize">The cipher key size. 256-bit is stronger, but slower.</param>
-        /// <returns>The Base64 encoded ciphertext.</returns>
-        public static string Encrypt(byte[] plaintext, string password, KeySize keySize)
+        /// <returns>The encoded ciphertext.</returns>
+        public static byte[] Encrypt(byte[] plaintext, string password, KeySize keySize)
         {
             // Generate a random IV
             var iv = Rng.GenerateRandomBytes(InitializationVectorSize);
@@ -51,7 +53,7 @@ namespace Rijndael256
             var ciphertext = Encrypt(plaintext, password, iv, keySize);
 
             // Encode the ciphertext
-            return Convert.ToBase64String(ciphertext);
+            return ciphertext;
         }
 
         /// <summary>
@@ -139,7 +141,19 @@ namespace Rijndael256
         /// <returns>The plaintext.</returns>
         public static string Decrypt(string ciphertext, string password, KeySize keySize)
         {
-            return Decrypt(Convert.FromBase64String(ciphertext), password, keySize);
+            using (var ms = new MemoryStream(Convert.FromBase64String(ciphertext)))
+            {
+                // Extract the IV from the ciphertext
+                var iv = new byte[InitializationVectorSize];
+                ms.Read(iv, 0, iv.Length);
+
+                // Create a CryptoStream to decrypt the ciphertext
+                using (var cs = new CryptoStream(ms, CreateDecryptor(password, iv, keySize), CryptoStreamMode.Read))
+                {
+                    // Decrypt the ciphertext
+                    using (var sr = new StreamReader(cs, Encoding.UTF8)) return sr.ReadToEnd();
+                }
+            }
         }
 
         /// <summary>
@@ -149,7 +163,7 @@ namespace Rijndael256
         /// <param name="password">The password to decrypt the ciphertext with.</param>
         /// <param name="keySize">The size of the cipher key used to create the ciphertext.</param>
         /// <returns>The plaintext.</returns>
-        public static string Decrypt(byte[] ciphertext, string password, KeySize keySize)
+        public static byte[] Decrypt(byte[] ciphertext, string password, KeySize keySize)
         {
             using (var ms = new MemoryStream(ciphertext))
             {
@@ -161,7 +175,12 @@ namespace Rijndael256
                 using (var cs = new CryptoStream(ms, CreateDecryptor(password, iv, keySize), CryptoStreamMode.Read))
                 {
                     // Decrypt the ciphertext
-                    using (var sr = new StreamReader(cs, Encoding.UTF8)) return sr.ReadToEnd();
+                    using (var buffer = new MemoryStream())
+                    {
+                        cs.CopyTo(buffer);
+
+                        return buffer.ToArray();
+                    }
                 }
             }
         }

--- a/Rijndael256/RijndaelEtM.cs
+++ b/Rijndael256/RijndaelEtM.cs
@@ -30,7 +30,7 @@ namespace Rijndael256
         /// <returns>The Base64 encoded EtM ciphertext.</returns>
         public static new string Encrypt(string plaintext, string password, KeySize keySize)
         {
-            return Convert.ToBase64String(Encrypt(Encoding.UTF8.GetBytes(plaintext), password, keySize));
+            return Encrypt(Encoding.UTF8.GetBytes(plaintext), password, keySize);
         }
 
         /// <summary>
@@ -41,8 +41,8 @@ namespace Rijndael256
         /// <param name="plaintext">The plaintext to encrypt.</param>
         /// <param name="password">The password to encrypt the plaintext with.</param>
         /// <param name="keySize">The cipher key size. 256-bit is stronger, but slower.</param>
-        /// <returns>The encoded EtM ciphertext.</returns>
-        public static new byte[] Encrypt(byte[] plaintext, string password, KeySize keySize)
+        /// <returns>The Base64 encoded EtM ciphertext.</returns>
+        public static new string Encrypt(byte[] plaintext, string password, KeySize keySize)
         {
             // Generate a random IV
             var iv = Rng.GenerateRandomBytes(InitializationVectorSize);
@@ -51,7 +51,7 @@ namespace Rijndael256
             var etmCiphertext = Encrypt(plaintext, password, iv, keySize);
 
             // Encode the EtM ciphertext
-            return etmCiphertext;
+            return Convert.ToBase64String(etmCiphertext);
         }
 
         /// <summary>
@@ -93,8 +93,7 @@ namespace Rijndael256
         /// <returns>The plaintext.</returns>
         public static new string Decrypt(string etmCiphertext, string password, KeySize keySize)
         {
-            return Encoding.UTF8.GetString(
-                Decrypt(Convert.FromBase64String(etmCiphertext), password, keySize));
+            return Decrypt(Convert.FromBase64String(etmCiphertext), password, keySize);
         }
 
         /// <summary>
@@ -105,7 +104,7 @@ namespace Rijndael256
         /// <param name="password">The password to decrypt the EtM ciphertext with.</param>
         /// <param name="keySize">The size of the cipher key used to create the EtM ciphertext.</param>
         /// <returns>The plaintext.</returns>
-        public static new byte[] Decrypt(byte[] etmCiphertext, string password, KeySize keySize)
+        public static new string Decrypt(byte[] etmCiphertext, string password, KeySize keySize)
         {
             // Generate AE keys
             var keyRing = AeKeyRing.Generate(password);

--- a/Rijndael256/RijndaelEtM.cs
+++ b/Rijndael256/RijndaelEtM.cs
@@ -30,7 +30,7 @@ namespace Rijndael256
         /// <returns>The Base64 encoded EtM ciphertext.</returns>
         public static new string Encrypt(string plaintext, string password, KeySize keySize)
         {
-            return Encrypt(Encoding.UTF8.GetBytes(plaintext), password, keySize);
+            return Convert.ToBase64String(Encrypt(Encoding.UTF8.GetBytes(plaintext), password, keySize));
         }
 
         /// <summary>
@@ -41,8 +41,8 @@ namespace Rijndael256
         /// <param name="plaintext">The plaintext to encrypt.</param>
         /// <param name="password">The password to encrypt the plaintext with.</param>
         /// <param name="keySize">The cipher key size. 256-bit is stronger, but slower.</param>
-        /// <returns>The Base64 encoded EtM ciphertext.</returns>
-        public static new string Encrypt(byte[] plaintext, string password, KeySize keySize)
+        /// <returns>The encoded EtM ciphertext.</returns>
+        public static new byte[] Encrypt(byte[] plaintext, string password, KeySize keySize)
         {
             // Generate a random IV
             var iv = Rng.GenerateRandomBytes(InitializationVectorSize);
@@ -51,7 +51,7 @@ namespace Rijndael256
             var etmCiphertext = Encrypt(plaintext, password, iv, keySize);
 
             // Encode the EtM ciphertext
-            return Convert.ToBase64String(etmCiphertext);
+            return etmCiphertext;
         }
 
         /// <summary>
@@ -93,7 +93,8 @@ namespace Rijndael256
         /// <returns>The plaintext.</returns>
         public static new string Decrypt(string etmCiphertext, string password, KeySize keySize)
         {
-            return Decrypt(Convert.FromBase64String(etmCiphertext), password, keySize);
+            return Encoding.UTF8.GetString(
+                Decrypt(Convert.FromBase64String(etmCiphertext), password, keySize));
         }
 
         /// <summary>
@@ -104,7 +105,7 @@ namespace Rijndael256
         /// <param name="password">The password to decrypt the EtM ciphertext with.</param>
         /// <param name="keySize">The size of the cipher key used to create the EtM ciphertext.</param>
         /// <returns>The plaintext.</returns>
-        public static new string Decrypt(byte[] etmCiphertext, string password, KeySize keySize)
+        public static new byte[] Decrypt(byte[] etmCiphertext, string password, KeySize keySize)
         {
             // Generate AE keys
             var keyRing = AeKeyRing.Generate(password);


### PR DESCRIPTION
I've introduced en- and decrypt functions without the string conversions and/or base64 encoding to allow encoding of binary data. Perhaps they are useful for someone else as well.